### PR TITLE
Improve schedule style with dark mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,20 @@
+const ROLES = new Set([
+  'PANEL',
+  'KEYNOTE',
+  'FIRESIDE CHAT',
+  'LIVE PODCAST',
+  'PITCH',
+  'IMPULS',
+  'GASTGEBER',
+  'PAUSE',
+  'MASTERCLASS',
+  'MASTERCLASS RAUM 1',
+  'MASTERCLASS RAUM 2',
+  'ROUNDTABLE',
+  'ROUNDTABLE RAUM 9',
+  'ROUNDTABLE RAUM 10 & 11',
+]);
+
 async function loadSlots() {
   const resp = await fetch('timeslots.json');
   const slots = await resp.json();
@@ -22,12 +39,28 @@ async function loadSlots() {
     });
     fetch('timeslots/'+slot.file).then(r=>r.text()).then(md => {
       const metaSec = clone.querySelector('.meta');
+      const tagWrap = clone.querySelector('.tags');
       const lines = md.split(/\r?\n/);
       let meta = [];
+      let tags = [];
       lines.forEach(line => {
-        if(line.startsWith('- ')) meta.push(line.substring(2));
+        if(!line.startsWith('- ')) return;
+        const item = line.substring(2).trim();
+        if(ROLES.has(item.toUpperCase())) {
+          tags.push(item);
+          return;
+        }
+        if(!line.startsWith('- Profil:') && !line.startsWith('- Grund:')) {
+          meta.push(item);
+        }
       });
       metaSec.textContent = meta.join(', ');
+      tags.forEach(t => {
+        const span = document.createElement('span');
+        span.className = 'tag';
+        span.textContent = t;
+        tagWrap.appendChild(span);
+      });
     });
     agenda.appendChild(clone);
   });

--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="theme-color" content="#121212" />
 <title>Hinterland of Things 2025</title>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;700&display=swap" rel="stylesheet">
 <link rel="manifest" href="manifest.webmanifest" />
 <link rel="stylesheet" href="style.css" />
 </head>
@@ -19,6 +22,7 @@
       <div class="time"></div>
       <button class="fav" aria-label="Favorit">&#9734;</button>
     </header>
+    <div class="tags"></div>
     <section class="meta"></section>
     <section class="why"><em>Warum teilnehmen? (Platzhalter)</em></section>
   </article>

--- a/style.css
+++ b/style.css
@@ -1,40 +1,68 @@
 body {
-  font-family: system-ui, sans-serif;
+  font-family: 'IBM Plex Sans', system-ui, sans-serif;
   margin: 0;
   padding: 0;
-  background: #f5f5f5;
-  color: #222;
+  background: #121212;
+  color: #eee;
+  line-height: 1.5;
 }
+
 header {
   background: #0057b8;
-  color: white;
+  color: #fff;
   padding: 1rem;
   text-align: center;
 }
+
 .slot {
-  background: white;
+  background: #1e1e1e;
   margin: 0.5rem;
   padding: 1rem;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.5);
 }
+
 .slot header {
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
+
+.slot .time {
+  font-size: 0.9rem;
+  color: #bbb;
+}
+
 .slot .fav {
   background: none;
   border: none;
   font-size: 1.5rem;
-  color: #ccc;
+  color: #888;
+  cursor: pointer;
 }
+
 .slot .fav.active {
   color: #e91e63;
 }
+
+.tags {
+  margin-top: 0.5rem;
+}
+
+.tag {
+  display: inline-block;
+  background: #0057b8;
+  color: #fff;
+  padding: 0 0.4rem;
+  margin-right: 0.25rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+}
+
 .meta {
   margin-top: 0.5rem;
 }
+
 @media (min-width: 600px) {
   .slot { max-width: 600px; margin: 1rem auto; }
 }


### PR DESCRIPTION
## Summary
- add IBM Plex Sans font and dark theme styling
- support tags for slot categories
- show tags parsed from timeslot metadata

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840b67961688321948c75662fbac431