### PR TITLE
Add short profiles for select agenda participants

### DIFF
--- a/agenda_timeslots.md
+++ b/agenda_timeslots.md
@@ -5,9 +5,11 @@
 - Eröffnung
 - Céline Flores Willers
 - THE People Branding Company
+- Kurzprofil: Unternehmerin, Speakerin und LinkedIn-Influencerin. Sie führt die People Branding Company.
 - Gastgeber
 - Simon Brakhage
 - Founders Foundation
+- Kurzprofil: Director "Hinterland of Things" bei der Founders Foundation.
 - Anna-luisa Korte
 - Founders Foundation
 

--- a/startups_split/akeno.md
+++ b/startups_split/akeno.md
@@ -1,7 +1,10 @@
 # Akeno
 Thema: Akeno
 Agenda: n/a
-Beteiligte Personen: n/a
+Beteiligte Personen:
+- Alexander Ebbrecht – Gründer und Geschäftsführer von akeno. Verantwortet die strategische Ausrichtung.
+- Dmitrij Direktor – Mitgründer von akeno mit Schwerpunkt auf Daten- und KI-Entwicklung.
+- Steffen Ramm – Mitgründer von akeno und Experte für Produktionsprozesse.
 
 Start: n/a
 End: n/a

--- a/timeslots/02-er-ffnung.md
+++ b/timeslots/02-er-ffnung.md
@@ -5,11 +5,13 @@ Beteiligte Personen:
 - Céline Flores Willers
 - THE People Branding Company
 - Profil: Céline Flores Willers von THE People Branding Company bringt Erfahrung in smart money.
+- Kurzprofil: Unternehmerin, Speakerin und LinkedIn-Influencerin. Gründerin der People Branding Company mit Fokus auf Personal Branding.
 - Grund: Sprechen Sie mit Céline Flores Willers, um mehr über smart money zu erfahren.
 - Gastgeber
 - Simon Brakhage
 - Founders Foundation
 - Profil: Simon Brakhage von Founders Foundation bringt Erfahrung in smart money.
+- Kurzprofil: Director "Hinterland of Things" bei der Founders Foundation. Verantwortlich für das Konferenzprogramm.
 - Grund: Sprechen Sie mit Simon Brakhage, um mehr über smart money zu erfahren.
 - Anna-luisa Korte
 - Founders Foundation


### PR DESCRIPTION
## Summary
- add short profiles to the opening timeslot
- expand akeno startup entry with founder info
- annotate the first agenda section with speaker details

## Testing
- `npm test` *(fails: no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840c7a9ac5c8321b0c5c4fdb342f8d1