### PR TITLE
Add offline micro animations

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,8 +21,10 @@ async function loadSlots() {
   const agenda = document.getElementById('agenda');
   const tmpl = document.getElementById('slot-template');
   const favs = JSON.parse(localStorage.getItem('favorites')||'[]');
-  slots.forEach(slot => {
+  slots.forEach((slot, idx) => {
     const clone = tmpl.content.firstElementChild.cloneNode(true);
+    clone.classList.add('appear');
+    clone.style.animationDelay = (idx * 0.05) + 's';
     clone.querySelector('.title').textContent = slot.title;
     clone.querySelector('.time').textContent = slot.start + (slot.end ? ' - '+slot.end : '');
     const btn = clone.querySelector('.fav');
@@ -35,6 +37,8 @@ async function loadSlots() {
         favs.push(slot.file);
         btn.classList.add('active');
       }
+      btn.classList.add('clicked');
+      btn.addEventListener('animationend', () => btn.classList.remove('clicked'), {once:true});
       localStorage.setItem('favorites', JSON.stringify(favs));
     });
     fetch('timeslots/'+slot.file).then(r=>r.text()).then(md => {

--- a/style.css
+++ b/style.css
@@ -107,3 +107,22 @@ h1 {
 #md-nav a:hover {
   text-decoration: underline;
 }
+/* Micro animations */
+@keyframes fade-slide {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.slot.appear {
+  animation: fade-slide 0.5s ease forwards;
+}
+
+@keyframes star-bounce {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.3); }
+  100% { transform: scale(1); }
+}
+
+.slot .fav.clicked {
+  animation: star-bounce 0.3s ease;
+}


### PR DESCRIPTION
## Summary
- introduce new CSS keyframes for fading slots and bouncing favorite icons
- hook animation classes into slot creation and favorite handling

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68412bb87acc8321be944aa1b3b56eb8