### PR TITLE
Make nav open on burger click

### DIFF
--- a/style.css
+++ b/style.css
@@ -108,18 +108,7 @@ body.nav-open #md-nav {
   transform: translateX(0);
 }
 @media (min-width: 600px) {
-  #md-nav {
-    position: static;
-    transform: none;
-    width: auto;
-  }
-  #menu-toggle {
-    display: none;
-  }
-  body {
-    padding-left: 0;
-  }
-  main {
+  body.nav-open main {
     margin-left: 260px;
   }
 }


### PR DESCRIPTION
## Summary
- keep hamburger menu visible on all screen sizes
- hide navigation by default and only push content when open

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68412e28eae88321ae1dc0b0810fcb9e