### PR TITLE
Add event overview landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # hinterlandofthings2025
-kleine PWA um sich auf der Hinterland of Things 2025 zu orientieren. offline und client-seitig
+Kleine PWA, um sich auf der Hinterland of Things 2025 zu orientieren. Offline und client-seitig. Die eigentliche PWA befindet sich nun unter `hinterland.html`. Eine neue Startseite `index.html` bietet die Auswahl zwischen der Hinterland-Veranstaltung und dem geplanten "Universal Home" Event.
 
 **Connection to Miele:** This content relates to ongoing work at Miele.
 

--- a/hinterland.html
+++ b/hinterland.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="theme-color" content="#0f0f0f" />
+<title>Hinterland of Things 2025</title>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+<link rel="manifest" href="manifest.webmanifest" />
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header>
+  <button id="menu-toggle" aria-label="Menü">&#9776;</button>
+  <h1>Hinterland of Things 2025</h1>
+</header>
+<nav id="md-nav">
+  <input type="text" id="nav-filter" placeholder="Filter" aria-label="Filter markdown files">
+  <ul id="nav-list"></ul>
+</nav>
+<main id="content"></main>
+<template id="slot-template">
+  <article class="slot">
+    <header>
+      <h2 class="title"></h2>
+      <div class="time"></div>
+      <button class="fav" aria-label="Favorit">&#9734;</button>
+    </header>
+    <div class="tags"></div>
+    <section class="meta"></section>
+    <section class="why"><em>Warum teilnehmen? Die Hinterland of Things 2025 bietet eine einzigartige Gelegenheit, die neuesten Entwicklungen in Technologie und Mittelstand kennenzulernen und wertvolle Kontakte zu innovativen Start-ups und etablierten Unternehmen zu knüpfen.</em></section>
+  </article>
+</template>
+<script src="marked.min.js"></script>
+<script src="app.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,38 +1,42 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en" data-bs-theme="dark">
 <head>
-<meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<meta name="theme-color" content="#0f0f0f" />
-<title>Hinterland of Things 2025</title>
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
-<link rel="manifest" href="manifest.webmanifest" />
-<link rel="stylesheet" href="style.css" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Event Overview</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
-<body>
-<header>
-  <button id="menu-toggle" aria-label="Menü">&#9776;</button>
-  <h1>Hinterland of Things 2025</h1>
-</header>
-<nav id="md-nav">
-  <input type="text" id="nav-filter" placeholder="Filter" aria-label="Filter markdown files">
-  <ul id="nav-list"></ul>
-</nav>
-<main id="content"></main>
-<template id="slot-template">
-  <article class="slot">
-    <header>
-      <h2 class="title"></h2>
-      <div class="time"></div>
-      <button class="fav" aria-label="Favorit">&#9734;</button>
-    </header>
-    <div class="tags"></div>
-    <section class="meta"></section>
-    <section class="why"><em>Warum teilnehmen? Die Hinterland of Things 2025 bietet eine einzigartige Gelegenheit, die neuesten Entwicklungen in Technologie und Mittelstand kennenzulernen und wertvolle Kontakte zu innovativen Start-ups und etablierten Unternehmen zu knüpfen.</em></section>
-  </article>
-</template>
-<script src="marked.min.js"></script>
-<script src="app.js"></script>
+<body class="bg-dark text-light">
+  <div class="container py-5">
+    <h1 class="text-center mb-4">Choose an Event</h1>
+    <div class="row justify-content-center">
+      <div class="col-md-5 mb-3">
+        <a href="hinterland.html" class="text-decoration-none text-light">
+          <div class="card bg-secondary">
+            <div class="card-body text-center">
+              <svg width="64" height="64" viewBox="0 0 64 64" class="mb-2" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <circle cx="32" cy="20" r="12" stroke="currentColor" stroke-width="4" fill="none"/>
+                <rect x="24" y="32" width="16" height="20" rx="8"/>
+                <line x1="32" y1="52" x2="32" y2="60" stroke="currentColor" stroke-width="4"/>
+              </svg>
+              <h2>Hinterland of Things 2025</h2>
+            </div>
+          </div>
+        </a>
+      </div>
+      <div class="col-md-5 mb-3">
+        <a href="universal-home.html" class="text-decoration-none text-light">
+          <div class="card bg-secondary">
+            <div class="card-body text-center">
+              <svg width="64" height="64" viewBox="0 0 64 64" class="mb-2" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <path d="M8 32 L32 12 L56 32 V56 H40 V40 H24 V56 H8 Z" stroke="currentColor" stroke-width="4" fill="none"/>
+              </svg>
+              <h2>Universal Home</h2>
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
 </body>
 </html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Hinterland of Things 2025",
   "short_name": "Hinterland",
-  "start_url": "./index.html",
+  "start_url": "./hinterland.html",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#ff0000",

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 const CACHE_NAME = 'hlt2025-cache-v2';
 const ASSETS = [
   './',
-  './index.html',
+  './hinterland.html',
   './style.css',
   './app.js',
   './marked.min.js',

--- a/universal-home.html
+++ b/universal-home.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Universal Home</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-dark text-light d-flex justify-content-center align-items-center" style="height:100vh;">
+  <div class="text-center">
+    <h1 class="mb-3">Universal Home</h1>
+    <p>Details coming soon.</p>
+    <a href="index.html" class="btn btn-outline-light mt-3">Back to overview</a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- rename existing conference page to `hinterland.html`
- add new `index.html` landing page using Bootstrap dark theme
- provide placeholder `universal-home.html`
- update service worker and manifest to reference `hinterland.html`
- document the new structure in `README`

## Testing
- `python3 -m py_compile add_profiles.py parse_items.py update_profiles.py`


------
https://chatgpt.com/codex/tasks/task_e_6848318b162c8321b629a1fff3ac3e68