### PR TITLE
Add Universal Home program schedule

### DIFF
--- a/universal-home.html
+++ b/universal-home.html
@@ -1,16 +1,434 @@
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="de" data-bs-theme="dark">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Universal Home</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>49. Universal Home Meeting by Miele</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+  :root {
+    --primary-blue: #00549F;
+    --primary-green: #4CAF50;
+    --primary-orange: #FF6F00;
+    --primary-gray: #607D8B;
+  }
+  body {
+    font-family: 'Segoe UI', system-ui;
+    margin: 0;
+    padding: 2rem;
+    background: #212529;
+  }
+  .header {
+    text-align: center;
+    margin-bottom: 3rem;
+    padding: 2rem;
+    background: #343a40;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    border-radius: 12px;
+  }
+  .filters {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    margin-bottom: 2rem;
+  }
+  .filter-btn {
+    padding: 0.8rem 1.5rem;
+    border: none;
+    border-radius: 25px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .filter-btn.active {
+    transform: scale(1.05);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  }
+  .events-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 2rem;
+    padding: 1rem;
+  }
+  .event-card {
+    background: #343a40;
+    color: #f8f9fa;
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 3px 6px rgba(0,0,0,0.1);
+    transition: transform 0.3s ease;
+    border-left: 4px solid;
+  }
+  .event-card:hover {
+    transform: translateY(-5px);
+  }
+  .event-time { color: #adb5bd; font-size: 0.9em; margin-bottom: 0.5rem; }
+  .event-title { font-size: 1.2em; margin: 0.5rem 0; color: #fff; }
+  .event-speaker { color: #ced4da; font-style: italic; margin: 0.5rem 0; }
+  .event-description { color: #dee2e6; line-height: 1.6; margin: 1rem 0; }
+  .ics-link {
+    display: inline-block;
+    padding: 0.6rem 1.2rem;
+    background: var(--primary-blue);
+    color: white;
+    text-decoration: none;
+    border-radius: 20px;
+    transition: background 0.3s ease;
+  }
+  .category-all { border-color: var(--primary-gray); }
+  .category-presentation { border-color: var(--primary-blue); }
+  .category-qa { border-color: var(--primary-green); }
+  .category-networking { border-color: var(--primary-orange); }
+  .filter-btn[data-category="all"] { background: var(--primary-gray); color: white; }
+  .filter-btn[data-category="presentation"] { background: var(--primary-blue); color: white; }
+  .filter-btn[data-category="qa"] { background: var(--primary-green); color: white; }
+  .filter-btn[data-category="networking"] { background: var(--primary-orange); color: white; }
+  </style>
 </head>
-<body class="bg-dark text-light d-flex justify-content-center align-items-center" style="height:100vh;">
-  <div class="text-center">
-    <h1 class="mb-3">Universal Home</h1>
-    <p>Details coming soon.</p>
-    <a href="index.html" class="btn btn-outline-light mt-3">Back to overview</a>
+<body>
+  <div class="header">
+    <h1>49. Universal Home Meeting by Miele</h1>
+    <p>11.-13. Juni 2025 | Gütersloh</p>
   </div>
+  <div class="filters">
+    <button class="filter-btn active" data-category="all">Alle Events</button>
+    <button class="filter-btn" data-category="presentation">Vorträge</button>
+    <button class="filter-btn" data-category="qa">Q&amp;A Sessions</button>
+    <button class="filter-btn" data-category="networking">Networking</button>
+  </div>
+  <div class="events-grid">
+    <!-- 11. Juni 2025 -->
+    <div class="event-card category-networking">
+      <div class="event-time">11.06.2025 | 18:00</div>
+      <h2 class="event-title">Check-in im Hotel</h2>
+      <div class="event-speaker">-</div>
+      <p class="event-description">Check-in im Holiday Inn Express Gütersloh</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-networking">
+      <div class="event-time">11.06.2025 | 19:00</div>
+      <h2 class="event-title">Get together und Spargel essen</h2>
+      <div class="event-speaker">-</div>
+      <p class="event-description">Gemeinsames Get-together und Spargel essen im Parkhotel Gütersloh</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <!-- 12. Juni 2025 -->
+    <div class="event-card category-networking">
+      <div class="event-time">12.06.2025 | 08:00</div>
+      <h2 class="event-title">Busabfahrt zum Meierhof Rassfeld</h2>
+      <div class="event-speaker">-</div>
+      <p class="event-description">Abfahrt des Busses vom Hotel zum Meierhof Rassfeld</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-networking">
+      <div class="event-time">12.06.2025 | 08:10</div>
+      <h2 class="event-title">Ankunft und erste Kommunikation</h2>
+      <div class="event-speaker">-</div>
+      <p class="event-description">Ankunft und erste Kommunikation am Meierhof Rassfeld</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">12.06.2025 | 08:20</div>
+      <h2 class="event-title">Begrüßung durch Miele</h2>
+      <div class="event-speaker">Andreas Enslin</div>
+      <p class="event-description">Begrüßungsrede von Andreas Enslin, Vice President Design Center bei Miele &amp; Cie. KG</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">12.06.2025 | 08:30</div>
+      <h2 class="event-title">Landebahn - was wirklich erforderlich ist, damit aus Ideen erfolgreiche Geschäfte werden</h2>
+      <div class="event-speaker">Andreas Enslin</div>
+      <p class="event-description">Vortrag über die Umsetzung von Ideen in erfolgreiche Geschäfte</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-qa">
+      <div class="event-time">12.06.2025 | 09:00</div>
+      <h2 class="event-title">Q &amp; A</h2>
+      <div class="event-speaker">Markus Wessel</div>
+      <p class="event-description">Q&amp;A-Session mit Markus Wessel, Universal Home</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">12.06.2025 | 09:10</div>
+      <h2 class="event-title">WHAT COULD POSSIBLY GO WRONG</h2>
+      <div class="event-speaker">Dr. Stefan Biel, Christoph Fischer</div>
+      <p class="event-description">Vortrag von Dr. Stefan Biel und Christoph Fischer von tesa SE</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">12.06.2025 | 09:30</div>
+      <h2 class="event-title">DER WEG ZU DEN BESTEN - Die Psychologie des Menschen, ist die am meisten unterschätzte Innovationsbarriere</h2>
+      <div class="event-speaker">Birgit Drixelius</div>
+      <p class="event-description">Vortrag über psychologische Innovationsbarrieren</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-qa">
+      <div class="event-time">12.06.2025 | 09:50</div>
+      <h2 class="event-title">Q &amp; A</h2>
+      <div class="event-speaker">Tom Rudolph</div>
+      <p class="event-description">Q&amp;A-Session mit Tom Rudolph, Miele</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-networking">
+      <div class="event-time">12.06.2025 | 10:00</div>
+      <h2 class="event-title">Kommunikationspause</h2>
+      <div class="event-speaker">-</div>
+      <p class="event-description">Pause für Kommunikation</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">12.06.2025 | 10:15</div>
+      <h2 class="event-title">Von der Technologie zur Wertschöpfung: Systematische Exploration und Validierung neuer Technologien für nachhaltige Innovation</h2>
+      <div class="event-speaker">Georgina Neitzel</div>
+      <p class="event-description">Vortrag über Technologieexploration und -validierung für nachhaltige Innovation</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-qa">
+      <div class="event-time">12.06.2025 | 10:45</div>
+      <h2 class="event-title">Q &amp; A</h2>
+      <div class="event-speaker">Matthias Nawrocki</div>
+      <p class="event-description">Q&amp;A-Session mit Matthias Nawrocki, ERGO Group AG</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">12.06.2025 | 10:55</div>
+      <h2 class="event-title">Daten und nachhaltigkeitsetriebene Innovation bei Vodafone - Was ist nötig, um neue Geschäftsmodelle umzusetzen?!</h2>
+      <div class="event-speaker">Michael Jakob Reinartz</div>
+      <p class="event-description">Vortrag über daten- und nachhaltigkeitsgetriebene Innovation bei Vodafone</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-qa">
+      <div class="event-time">12.06.2025 | 11:25</div>
+      <h2 class="event-title">Q &amp; A</h2>
+      <div class="event-speaker">Matthias Nawrocki</div>
+      <p class="event-description">Q&amp;A-Session mit Matthias Nawrocki, ERGO Group AG</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">12.06.2025 | 11:35</div>
+      <h2 class="event-title">Wir bleiben aus Tradition innovativ: ein Weg zwischen Genialität und Zufall</h2>
+      <div class="event-speaker">Andreas Schobert</div>
+      <p class="event-description">Vortrag über Innovation durch Tradition</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-qa">
+      <div class="event-time">12.06.2025 | 12:05</div>
+      <h2 class="event-title">Q &amp; A</h2>
+      <div class="event-speaker">Joachim De Backer</div>
+      <p class="event-description">Q&amp;A-Session mit Joachim De Backer, Hettich Marketing- und Vertriebs GmbH</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-networking">
+      <div class="event-time">12.06.2025 | 12:15</div>
+      <h2 class="event-title">Gemeinsames Mittagessen und Kommunikationszeit</h2>
+      <div class="event-speaker">-</div>
+      <p class="event-description">Mittagessen und Zeit für Kommunikation</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">12.06.2025 | 13:00</div>
+      <h2 class="event-title">VIVA la REWElution - Innovation braucht Macher!</h2>
+      <div class="event-speaker">Jörg Hirt</div>
+      <p class="event-description">Vortrag über Innovation bei REWE digital</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-qa">
+      <div class="event-time">12.06.2025 | 13:40</div>
+      <h2 class="event-title">Q &amp; A</h2>
+      <div class="event-speaker">Tom Rudolph</div>
+      <p class="event-description">Q&amp;A-Session mit Tom Rudolph, Miele &amp; Cie. KG</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">12.06.2025 | 13:50</div>
+      <h2 class="event-title">Innovation ist kein Zufall - Wie WILO die Zukunft gestaltet und Wirkung schafft</h2>
+      <div class="event-speaker">Dr. Stefan Neuhaus</div>
+      <p class="event-description">Vortrag über Innovation bei WILO SE</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-qa">
+      <div class="event-time">12.06.2025 | 14:20</div>
+      <h2 class="event-title">Q &amp; A</h2>
+      <div class="event-speaker">Swen Schneider</div>
+      <p class="event-description">Q&amp;A-Session mit Swen Schneider, Miele &amp; Cie. KG</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">12.06.2025 | 14:30</div>
+      <h2 class="event-title">Was erwarten Kunden von einer Marke? Kontinuität vs. Veränderung - Entscheidungshilfen durch den Customer Centricity Score</h2>
+      <div class="event-speaker">Prof. Dr. Jan-Erik Baars</div>
+      <p class="event-description">Vortrag über Kundenerwartungen an Marken</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-qa">
+      <div class="event-time">12.06.2025 | 15:00</div>
+      <h2 class="event-title">Q &amp; A</h2>
+      <div class="event-speaker">Andreas Enslin</div>
+      <p class="event-description">Q&amp;A-Session mit Andreas Enslin, Miele &amp; Cie. KG</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-networking">
+      <div class="event-time">12.06.2025 | 15:10</div>
+      <h2 class="event-title">Busfahrt zur New Growth Factory</h2>
+      <div class="event-speaker">-</div>
+      <p class="event-description">Busfahrt zur New Growth Factory</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">12.06.2025 | 15:30</div>
+      <h2 class="event-title">Besichtigung der New Growth Factory von Miele + Vortrag</h2>
+      <div class="event-speaker">Gernot Trettenbrein, Dr. Ina Nordsiek</div>
+      <p class="event-description">Besichtigung und Vortrag in der New Growth Factory von Miele</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-networking">
+      <div class="event-time">12.06.2025 | 17:00</div>
+      <h2 class="event-title">Busfahrt zurück zum Meierhof Rassfeld</h2>
+      <div class="event-speaker">-</div>
+      <p class="event-description">Busfahrt zurück zum Meierhof Rassfeld</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-networking">
+      <div class="event-time">12.06.2025 | 17:30</div>
+      <h2 class="event-title">Das Miele-Flammenfest mit Otto Wilde im Meierhof Rassfeld</h2>
+      <div class="event-speaker">-</div>
+      <p class="event-description">Miele-Flammenfest mit Otto Wilde</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">12.06.2025 | 18:30</div>
+      <h2 class="event-title">Vortrag über Bildung und Innovation</h2>
+      <div class="event-speaker">Dr. Peter Rösner, Tara Siempelkamp, Philipp Grieffenhagen</div>
+      <p class="event-description">Vortrag von Dr. Peter Rösner und Schülern des Internats Louisenlund</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-qa">
+      <div class="event-time">12.06.2025 | 19:15</div>
+      <h2 class="event-title">Q &amp; A</h2>
+      <div class="event-speaker">Markus Wessel</div>
+      <p class="event-description">Q&amp;A-Session mit Markus Wessel, Universal Home GmbH</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-networking">
+      <div class="event-time">12.06.2025 | 19:30</div>
+      <h2 class="event-title">Get together</h2>
+      <div class="event-speaker">-</div>
+      <p class="event-description">Geselliges Beisammensein</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-networking">
+      <div class="event-time">12.06.2025 | ca. 22:00</div>
+      <h2 class="event-title">Rückfahrt zum Hotel</h2>
+      <div class="event-speaker">-</div>
+      <p class="event-description">Busfahrt zurück zum Hotel</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <!-- 13. Juni 2025 -->
+    <div class="event-card category-networking">
+      <div class="event-time">13.06.2025 | ab 08:15</div>
+      <h2 class="event-title">Ankunft und erste Kommunikation</h2>
+      <div class="event-speaker">-</div>
+      <p class="event-description">Ankunft und erste Kommunikation an der Studiobühne Gütersloh</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">13.06.2025 | 08:30</div>
+      <h2 class="event-title">Begrüßung durch Miele</h2>
+      <div class="event-speaker">Dr. Markus Miele</div>
+      <p class="event-description">Begrüßungsrede von Dr. Markus Miele, Geschäftsführender Gesellschafter bei Miele &amp; Cie. KG</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">13.06.2025 | 08:35</div>
+      <h2 class="event-title">Klare, einfache und handlungsfähige Innovationsstrategien für Mittelstand und Industrie - Geht das überhaupt?</h2>
+      <div class="event-speaker">Manfred Tropper</div>
+      <p class="event-description">Vortrag über Innovationsstrategien für Mittelstand und Industrie</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-qa">
+      <div class="event-time">13.06.2025 | 09:05</div>
+      <h2 class="event-title">Q &amp; A</h2>
+      <div class="event-speaker">Andreas Enslin</div>
+      <p class="event-description">Q&amp;A-Session mit Andreas Enslin, Miele &amp; Cie. KG</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">13.06.2025 | 10:00</div>
+      <h2 class="event-title">"Qualitatives Wachstum" vs. "Quantitatives Wachstum" - Kundenanforderungen der Zukunft an Marke und Design am Beispiel Miele</h2>
+      <div class="event-speaker">Dr. Reinhard Zinkann</div>
+      <p class="event-description">Vortrag über qualitatives vs. quantitatives Wachstum und zukünftige Kundenanforderungen</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-qa">
+      <div class="event-time">13.06.2025 | 10:30</div>
+      <h2 class="event-title">Q &amp; A</h2>
+      <div class="event-speaker">Dr. Thomas Becker</div>
+      <p class="event-description">Q&amp;A-Session mit Dr. Thomas Becker, Geschäftsführer und CTO der ABUS August Bremicker Söhne KG</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-networking">
+      <div class="event-time">13.06.2025 | 10:40</div>
+      <h2 class="event-title">Kommunikationspause</h2>
+      <div class="event-speaker">-</div>
+      <p class="event-description">Pause für Kommunikation</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">13.06.2025 | 11:00</div>
+      <h2 class="event-title">Wo sich die Führungskräfte der Zukunft bilden - über Verantwortung, Unternehmertum und TOP-Talentförderung</h2>
+      <div class="event-speaker">Dr. Peter Rösner, Tara Siempelkamp, Philipp Grieffenhagen</div>
+      <p class="event-description">Vortrag über die Bildung zukünftiger Führungskräfte</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-qa">
+      <div class="event-time">13.06.2025 | 11:30</div>
+      <h2 class="event-title">Q &amp; A</h2>
+      <div class="event-speaker">Markus Wessel</div>
+      <p class="event-description">Q&amp;A-Session mit Markus Wessel, Universal Home</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">13.06.2025 | 11:40</div>
+      <h2 class="event-title">Hettich SpinLines - Drehen nicht immer rund</h2>
+      <div class="event-speaker">Daniel Rehage, Joachim De Backer</div>
+      <p class="event-description">Vortrag über Hettich SpinLines</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-qa">
+      <div class="event-time">13.06.2025 | 12:10</div>
+      <h2 class="event-title">Q &amp; A</h2>
+      <div class="event-speaker">Thomas Müller</div>
+      <p class="event-description">Q&amp;A-Session mit Thomas Müller, Geschäftsführer der STEINEL GmbH</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-networking">
+      <div class="event-time">13.06.2025 | 12:20</div>
+      <h2 class="event-title">Fingerfood und Kommunikation</h2>
+      <div class="event-speaker">-</div>
+      <p class="event-description">Fingerfood und Zeit für Kommunikation</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+    <div class="event-card category-presentation">
+      <div class="event-time">13.06.2025 | 12:45</div>
+      <h2 class="event-title">Innere und äußere Ressourcen, die Innovationen ermöglichen</h2>
+      <div class="event-speaker">-</div>
+      <p class="event-description">Vortrag über Ressourcen, die Innovationen ermöglichen</p>
+      <a href="#" class="ics-link">Zu Outlook hinzufügen</a>
+    </div>
+  </div>
+  <script>
+    document.querySelectorAll('.filter-btn').forEach(button => {
+      button.addEventListener('click', () => {
+        document.querySelectorAll('.filter-btn').forEach(btn => btn.classList.remove('active'));
+        button.classList.add('active');
+        const category = button.dataset.category;
+        document.querySelectorAll('.event-card').forEach(card => {
+          card.style.display = category === 'all' || card.classList.contains(`category-${category}`) ? 'block' : 'none';
+        });
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace placeholder Universal Home page with complete program schedule
- include filtering of presentations, Q&A, and networking events
- keep dark bootstrap design with custom categories

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684832451ab88321aa2769f3aca9fb70