### PR TITLE
Improve agenda layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,7 +18,8 @@ const ROLES = new Set([
 async function loadSlots() {
   const resp = await fetch('timeslots.json');
   const slots = await resp.json();
-  const agenda = document.getElementById('content');
+  const day1 = document.getElementById('day1');
+  const day2 = document.getElementById('day2');
   const tmpl = document.getElementById('slot-template');
   const favs = JSON.parse(localStorage.getItem('favorites')||'[]');
   slots.forEach((slot, idx) => {
@@ -66,7 +67,12 @@ async function loadSlots() {
         tagWrap.appendChild(span);
       });
     });
-    agenda.appendChild(clone);
+    const num = parseInt(slot.file, 10);
+    if(num <= 36) {
+      day1.appendChild(clone);
+    } else if(num <= 70) {
+      day2.appendChild(clone);
+    }
   });
 }
 

--- a/hinterland.html
+++ b/hinterland.html
@@ -19,7 +19,10 @@
   <input type="text" id="nav-filter" placeholder="Filter" aria-label="Filter markdown files">
   <ul id="nav-list"></ul>
 </nav>
-<main id="content"></main>
+<main id="content">
+  <section id="day1" class="day-column"><h2>Tag 1</h2></section>
+  <section id="day2" class="day-column"><h2>Tag 2</h2></section>
+</main>
 <template id="slot-template">
   <article class="slot">
     <header>

--- a/style.css
+++ b/style.css
@@ -161,3 +161,19 @@ body.nav-open #md-nav {
 .slot .fav.clicked {
   animation: star-bounce 0.3s ease;
 }
+
+#content {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.day-column {
+  flex: 1;
+  min-width: 300px;
+}
+
+.day-column h2 {
+  text-align: center;
+  margin-top: 0;
+}


### PR DESCRIPTION
## Summary
- show 2 day columns in agenda
- style day columns with flexbox layout
- assign timeslots to each day

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68483c2aba7883218f52b2c74e8e620f