### PR TITLE
Implement grid-based timeslots view

### DIFF
--- a/universal-app.js
+++ b/universal-app.js
@@ -1,10 +1,32 @@
+function toMinutes(t){
+  const [h,m] = t.split(':').map(Number);
+  return h*60 + m;
+}
+
 async function loadSlots(){
   const resp = await fetch('universal-timeslots.json');
   const slots = await resp.json();
-  const day1 = document.getElementById('day1');
-  const day2 = document.getElementById('day2');
-  const day3 = document.getElementById('day3');
+  const days = {
+    1: document.getElementById('day1'),
+    2: document.getElementById('day2'),
+    3: document.getElementById('day3')
+  };
   const tmpl = document.getElementById('slot-template');
+
+  const dayStarts = {};
+  const dayEnds = {};
+  slots.forEach(s => {
+    const start = toMinutes(s.start);
+    const end = toMinutes(s.end);
+    if(!(s.day in dayStarts) || start < dayStarts[s.day]) dayStarts[s.day] = start;
+    if(!(s.day in dayEnds) || end > dayEnds[s.day]) dayEnds[s.day] = end;
+  });
+
+  Object.keys(days).forEach(day => {
+    const rows = Math.ceil((dayEnds[day] - dayStarts[day]) / 15);
+    days[day].style.gridTemplateRows = `repeat(${rows}, 15px)`;
+  });
+
   slots.forEach(slot => {
     const clone = tmpl.content.firstElementChild.cloneNode(true);
     clone.querySelector('.title').textContent = slot.title;
@@ -12,9 +34,12 @@ async function loadSlots(){
     clone.querySelector('.speaker').textContent = slot.speaker;
     clone.querySelector('.desc').textContent = slot.description;
     clone.querySelector('.ics-link').href = slot.ics;
-    if(slot.day === 1) day1.appendChild(clone);
-    else if(slot.day === 2) day2.appendChild(clone);
-    else day3.appendChild(clone);
+
+    const startRow = Math.floor((toMinutes(slot.start) - dayStarts[slot.day]) / 15) + 1;
+    const span = Math.ceil((toMinutes(slot.end) - toMinutes(slot.start)) / 15);
+    clone.style.gridRow = `${startRow} / span ${span}`;
+
+    days[slot.day].appendChild(clone);
   });
 }
 loadSlots();

--- a/universal-home-timeslots.html
+++ b/universal-home-timeslots.html
@@ -5,13 +5,38 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Universal Home - Zeitplan</title>
 <link rel="stylesheet" href="style.css" />
+<style>
+  #content.grid-schedule {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+  #content.grid-schedule .day-column {
+    flex: 1;
+    min-width: 300px;
+    display: grid;
+    grid-auto-rows: 15px;
+    gap: 0.25rem;
+    position: relative;
+  }
+  #content.grid-schedule .day-column h2 {
+    grid-column: 1 / -1;
+    text-align: center;
+    margin-top: 0;
+    position: sticky;
+    top: 0;
+    background: #212121;
+    z-index: 1;
+  }
+  #content.grid-schedule .slot { margin: 0; }
+</style>
 </head>
 <body>
 <header>
   <h1>Universal Home Meeting</h1>
   <a href="universal-home.html" style="color:#ff0000">Kartenansicht</a>
 </header>
-<main id="content">
+<main id="content" class="grid-schedule">
   <section id="day1" class="day-column"><h2>Tag 1</h2></section>
   <section id="day2" class="day-column"><h2>Tag 2</h2></section>
   <section id="day3" class="day-column"><h2>Tag 3</h2></section>


### PR DESCRIPTION
## Summary
- align Universal Home time slots to a 15‑minute grid
- style Universal Home timeslot view with grid layout

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6848422202cc8321bd06fb9aad1f8853