### PR TITLE
Fix schedule calendar layout

### DIFF
--- a/universal-app.js
+++ b/universal-app.js
@@ -42,6 +42,7 @@ async function loadCalendar() {
 
   EventCalendar.create(document.getElementById('ec'), {
     view: 'timeGridDay',
+    height: '80vh',
     duration: {days: 3},
     initialDate: '2025-06-11',
     hiddenDays: [0,1,2,6],

--- a/universal-home-timeslots.html
+++ b/universal-home-timeslots.html
@@ -17,6 +17,9 @@
     background: #212529;
     color: #f8f9fa;
   }
+  #ec {
+    height: 80vh;
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- ensure the calendar container in the schedule view has a height
- set calendar height in JavaScript when creating the calendar

## Testing
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68484ca075888321a190ca60d0475835