### PR TITLE
Add environment-based login configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+EMAIL=your_email@example.com
+PASSWORD=your_password

--- a/README.md
+++ b/README.md
@@ -6,3 +6,14 @@ Kleine PWA, um sich auf der Hinterland of Things 2025 zu orientieren. Offline un
 ## Warum teilnehmen?
 
 Als KI-Sprachmodell erkenne ich hier zahlreiche Chancen: Die Veranstaltung bietet Einblicke in neue Technologien, ermöglicht wertvolle Kontakte und inspiriert zu innovativen Ideen. Teilnehmende können voneinander lernen und gemeinsam die Zukunft gestalten.
+
+## Configuration
+
+The application reads login credentials from a `.env` file located in the project root. This file should contain the following variables:
+
+```
+EMAIL=your_email@example.com
+PASSWORD=your_password
+```
+
+Adjust these values to control access when deploying the site.

--- a/login.js
+++ b/login.js
@@ -1,14 +1,39 @@
 const form = document.querySelector('form');
-if(form){
-  form.addEventListener('submit', e => {
-    e.preventDefault();
-    const email = document.getElementById('email').value;
-    const password = document.getElementById('password').value;
-    if(email === 'henrikholkenbrink@gmail.com' && password === '1234asdf'){
-      localStorage.setItem('loggedIn', 'true');
-      window.location.href = '../index.html';
-    } else {
-      alert('Invalid credentials');
-    }
-  });
+let env = { EMAIL: '', PASSWORD: '' };
+
+function parseEnv(text) {
+  return text.split('\n').reduce((acc, line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) return acc;
+    const [key, ...rest] = trimmed.split('=');
+    acc[key] = rest.join('=');
+    return acc;
+  }, {});
 }
+
+function handleSubmit(e) {
+  e.preventDefault();
+  const email = document.getElementById('email').value;
+  const password = document.getElementById('password').value;
+  if (email === env.EMAIL && password === env.PASSWORD) {
+    localStorage.setItem('loggedIn', 'true');
+    window.location.href = '../index.html';
+  } else {
+    alert('Invalid credentials');
+  }
+}
+
+function init() {
+  fetch('../.env')
+    .then(res => (res.ok ? res.text() : ''))
+    .then(text => {
+      env = Object.assign(env, parseEnv(text));
+    })
+    .finally(() => {
+      if (form) {
+        form.addEventListener('submit', handleSubmit);
+      }
+    });
+}
+
+init();


### PR DESCRIPTION
## Summary
- add a `.env` file that stores login credentials
- fetch credentials from `.env` in `login.js`
- document new configuration step in `README.md`

## Testing
- `npm test` *(fails: could not find package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684f17bc44d08321ad5c55d705b2b904