### PR TITLE
fix: load login credentials from json

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ Als KI-Sprachmodell erkenne ich hier zahlreiche Chancen: Die Veranstaltung biete
 
 ## Configuration
 
-The application reads login credentials from a `.env` file located in the project root. This file should contain the following variables:
+The application reads login credentials from `env.json` located in the project root. This file should contain a JSON object:
 
 ```
-EMAIL=your_email@example.com
-PASSWORD=your_password
+{
+  "EMAIL": "your_email@example.com",
+  "PASSWORD": "your_password"
+}
 ```
 
 Adjust these values to control access when deploying the site.

--- a/env.json
+++ b/env.json
@@ -1,0 +1,4 @@
+{
+  "EMAIL": "Henrikholkenbrink@gmail.com",
+  "PASSWORD": "689i9052A.hint"
+}

--- a/login.js
+++ b/login.js
@@ -1,16 +1,6 @@
 const form = document.querySelector('form');
 let env = { EMAIL: '', PASSWORD: '' };
 
-function parseEnv(text) {
-  return text.split('\n').reduce((acc, line) => {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) return acc;
-    const [key, ...rest] = trimmed.split('=');
-    acc[key] = rest.join('=');
-    return acc;
-  }, {});
-}
-
 function handleSubmit(e) {
   e.preventDefault();
   const email = document.getElementById('email').value;
@@ -24,10 +14,10 @@ function handleSubmit(e) {
 }
 
 function init() {
-  fetch('../.env')
-    .then(res => (res.ok ? res.text() : ''))
-    .then(text => {
-      env = Object.assign(env, parseEnv(text));
+  fetch('../env.json')
+    .then(res => (res.ok ? res.json() : {}))
+    .then(data => {
+      env = Object.assign(env, data);
     })
     .finally(() => {
       if (form) {


### PR DESCRIPTION
## Summary
- load login credentials from `env.json` without modifying `.env`
- update login script to read credentials from JSON config
- document new JSON-based credential configuration

## Testing
- `npm test` *(fails: missing package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_689434c8902883219bf2226b29ec71bf