### PR TITLE
Prevent service worker from handling non-GET requests

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -25,6 +25,10 @@ self.addEventListener('install', event => {
   );
 });
 self.addEventListener('fetch', event => {
+  // Only handle GET requests; allow other methods like POST to pass through
+  if (event.request.method !== 'GET') {
+    return;
+  }
   event.respondWith(
     caches.match(event.request).then(resp => resp || fetch(event.request))
   );


### PR DESCRIPTION
## Summary
- Skip non-GET requests in the service worker fetch handler so posts like login submissions no longer trigger 405 errors.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68944a2bb948832183a189ef0fbd1b83