### PR TITLE
Simplify login to password only

### DIFF
--- a/credentials.js
+++ b/credentials.js
@@ -1,1 +1,1 @@
-window.CREDENTIALS = { email: 'henrikholkenbrink@gmail.com', password: '689i9052A.hint' };
+window.CREDENTIALS = { password: '689i9052A.hint' };

--- a/login.html
+++ b/login.html
@@ -16,10 +16,6 @@
         <form id="login-form" class="glass p-4">
           <h2 class="text-center mb-4">Login</h2>
           <div class="mb-3">
-            <label for="email" class="form-label">E-Mail</label>
-            <input type="email" class="form-control" id="email" name="email" required>
-          </div>
-          <div class="mb-3">
             <label for="password" class="form-label">Passwort</label>
             <input type="password" class="form-control" id="password" name="password" required>
           </div>

--- a/login.js
+++ b/login.js
@@ -1,18 +1,11 @@
-async function hash(str) {
-  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(str));
-  return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
-}
-
-document.getElementById('login-form').addEventListener('submit', async (e) => {
+document.getElementById('login-form').addEventListener('submit', (e) => {
   e.preventDefault();
-  const email = e.target.email.value;
   const password = e.target.password.value;
-  const emailHash = await hash(email);
-  const passwordHash = await hash(password);
-  if (emailHash === CREDENTIALS.email && passwordHash === CREDENTIALS.password) {
+  if (password === CREDENTIALS.password) {
     localStorage.setItem('auth', 'true');
     window.location.href = 'index.html';
   } else {
     alert('Falsche Zugangsdaten');
   }
 });
+


### PR DESCRIPTION
## Summary
- fix credentials mismatch by comparing plaintext password
- drop email input for a minimal password-only login

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689466fcb29c832192ac9d4888bb85db