### PR TITLE
Add Henrik portfolio with scroll and particle effects

### DIFF
--- a/portfolio-henrik/about.html
+++ b/portfolio-henrik/about.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>About – Henrik Holkenbrink</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+<canvas id="particles"></canvas>
+<header class="container nav">
+  <a href="index.html" class="logo">← Zurück</a>
+  <nav class="nav-links">
+    <a href="work.html">Work</a>
+    <a href="approach.html">Approach</a>
+    <a href="about.html">About</a>
+    <a href="writing.html">Writing</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+<main class="container section">
+  <h1 class="reveal">About</h1>
+  <p class="reveal">Strategic Concepter bei Miele Smart Home – Future Business Design in Bielefeld; Fokus auf Identifikation neuer Geschäftsfelder und Validierung vernetzter Produktlösungen.</p>
+  <p class="reveal" style="margin-top:20px;">Hintergrund in Advanced Product Design mit starker Schnittstelle zu Technologie & Fertigung; Praxis zwischen Hardware, Software und Service.</p>
+  <p class="reveal" style="margin-top:20px;">Aktiv im regionalen Innovations- und Gründungsumfeld.</p>
+  <p class="reveal" style="margin-top:20px;">Standort: Bielefeld, NRW</p>
+</main>
+<footer class="footer">
+  © <span id="y"></span> Henrik Holkenbrink · <a href="contact.html">Kontakt</a>
+</footer>
+<script src="assets/script.js"></script>
+</body>
+</html>

--- a/portfolio-henrik/approach.html
+++ b/portfolio-henrik/approach.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Approach – Henrik Holkenbrink</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+<canvas id="particles"></canvas>
+<header class="container nav">
+  <a href="index.html" class="logo">← Zurück</a>
+  <nav class="nav-links">
+    <a href="work.html">Work</a>
+    <a href="approach.html">Approach</a>
+    <a href="about.html">About</a>
+    <a href="writing.html">Writing</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+<main class="container section">
+  <h1 class="reveal">Approach</h1>
+  <div class="reveal">
+    <h2>Arbeitsprinzipien</h2>
+    <ul>
+      <li>Vision to Validation: Von strategischer Vision über Hypothesen zu messbaren Piloten.</li>
+      <li>Dual Track: Discovery und Delivery verzahnt.</li>
+      <li>Evidence-Led: Entscheidungen auf Nutzersignalen und Business-Impact stützen.</li>
+    </ul>
+  </div>
+  <div class="reveal" style="margin-top:40px;">
+    <h2>Methoden-Toolkit</h2>
+    <ul>
+      <li>Opportunity Mapping, JTBD, Value Proposition Design</li>
+      <li>Service Blueprints, Interaction Flows, Design Sprints</li>
+      <li>Experiment-Design: Smoke Tests, Click Dummies, Concierge MVPs</li>
+      <li>Portfolio-Priorisierung: Impact vs. Effort, Risk-Weighted Backlogs</li>
+    </ul>
+  </div>
+  <div class="reveal" style="margin-top:40px;">
+    <h2>Ergebnisorientierung</h2>
+    <ul>
+      <li>Validierungsartefakte: Hypothesen, Metriken, Entscheidungs-Logs</li>
+      <li>Transfer in Roadmap mit Ownership und Next Steps</li>
+    </ul>
+  </div>
+</main>
+<footer class="footer">
+  © <span id="y"></span> Henrik Holkenbrink · <a href="contact.html">Kontakt</a>
+</footer>
+<script src="assets/script.js"></script>
+</body>
+</html>

--- a/portfolio-henrik/assets/script.js
+++ b/portfolio-henrik/assets/script.js
@@ -1,0 +1,47 @@
+// Scroll reveal
+const observer = new IntersectionObserver(entries => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) entry.target.classList.add('show');
+  });
+});
+document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+
+// Set current year
+const y = document.getElementById('y');
+if (y) y.textContent = new Date().getFullYear();
+
+// Simple particle effect
+const canvas = document.getElementById('particles');
+if (canvas) {
+  const ctx = canvas.getContext('2d');
+  let particles = [];
+  function resize() {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+  }
+  window.addEventListener('resize', resize);
+  resize();
+  for (let i = 0; i < 80; i++) {
+    particles.push({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      vx: (Math.random() - 0.5) * 0.5,
+      vy: (Math.random() - 0.5) * 0.5
+    });
+  }
+  function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = 'rgba(0,0,0,0.5)';
+    particles.forEach(p => {
+      p.x += p.vx;
+      p.y += p.vy;
+      if (p.x < 0 || p.x > canvas.width) p.vx *= -1;
+      if (p.y < 0 || p.y > canvas.height) p.vy *= -1;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, 1.5, 0, Math.PI * 2);
+      ctx.fill();
+    });
+    requestAnimationFrame(draw);
+  }
+  draw();
+}

--- a/portfolio-henrik/assets/styles.css
+++ b/portfolio-henrik/assets/styles.css
@@ -1,0 +1,24 @@
+*{box-sizing:border-box;margin:0;padding:0}
+html{scroll-behavior:smooth}
+body{font:16px/1.5 Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#111;background:#fff}
+a{color:#a40000;text-decoration:none}
+a:hover{text-decoration:underline}
+.container{max-width:960px;margin:0 auto;padding:24px}
+.nav{display:flex;align-items:center;justify-content:space-between;margin-top:16px}
+.logo{font-weight:700;font-size:22px;color:#111}
+.nav-links a{margin-left:16px;font-weight:500}
+.hero{min-height:80vh;display:flex;flex-direction:column;justify-content:center}
+.hero h1{font-size:48px;line-height:1.1;margin-bottom:16px}
+.btn{display:inline-block;background:#111;color:#fff;padding:12px 18px;border-radius:4px;margin-right:12px}
+.btn:hover{opacity:.9;text-decoration:none}
+.section{padding:80px 0}
+.reveal{opacity:0;transform:translateY(20px);transition:all .6s ease-out}
+.reveal.show{opacity:1;transform:none}
+.case{border-top:1px solid #eee;padding:24px 0}
+.tags{color:#555;font-size:14px;margin-top:4px}
+.footer{border-top:1px solid #ddd;margin-top:80px;padding:24px;font-size:14px;color:#555;text-align:center}
+form{margin-top:20px}
+label{display:block;margin:10px 0 4px}
+input,textarea{width:100%;padding:10px;border:1px solid #ddd;border-radius:4px}
+.btn-form{background:#a40000;color:#fff;padding:10px 16px;border:none;border-radius:4px;margin-top:10px;cursor:pointer}
+#particles{position:fixed;top:0;left:0;width:100%;height:100%;z-index:-1}

--- a/portfolio-henrik/contact.html
+++ b/portfolio-henrik/contact.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Kontakt – Henrik Holkenbrink</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+<canvas id="particles"></canvas>
+<header class="container nav">
+  <a href="index.html" class="logo">← Zurück</a>
+  <nav class="nav-links">
+    <a href="work.html">Work</a>
+    <a href="approach.html">Approach</a>
+    <a href="about.html">About</a>
+    <a href="writing.html">Writing</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+<main class="container section">
+  <h1 class="reveal">Kontakt</h1>
+  <p class="reveal">Am besten erreichbar per E-Mail oder LinkedIn.</p>
+  <p class="reveal">E-Mail: <a href="mailto:henrik@example.com">henrik@example.com</a><br>LinkedIn: <a href="https://www.linkedin.com/in/henrikholkenbrink/" target="_blank">Profil</a></p>
+  <form class="reveal">
+    <label for="name">Name</label>
+    <input id="name" type="text">
+    <label for="email">Email</label>
+    <input id="email" type="email">
+    <label for="msg">Nachricht</label>
+    <textarea id="msg" rows="4"></textarea>
+    <button class="btn-form" type="submit">Senden</button>
+  </form>
+</main>
+<footer class="footer">
+  © <span id="y"></span> Henrik Holkenbrink
+</footer>
+<script src="assets/script.js"></script>
+</body>
+</html>

--- a/portfolio-henrik/index.html
+++ b/portfolio-henrik/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Henrik Holkenbrink – Portfolio</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+<canvas id="particles"></canvas>
+<header class="container nav">
+  <div class="logo">HH</div>
+  <nav class="nav-links">
+    <a href="work.html">Work</a>
+    <a href="approach.html">Approach</a>
+    <a href="about.html">About</a>
+    <a href="writing.html">Writing</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+<main class="container hero">
+  <h1 class="reveal">Zukunft gestalten: Von Vision zu validiertem Geschäftsmodell.</h1>
+  <p class="reveal">Strategic Concepter bei Miele Smart Home – Future Business Design. Ich identifiziere neue Geschäftsfelder und entwickle aus Technologien marktfähige Lösungen.</p>
+  <div class="reveal" style="margin-top:24px;">
+    <a class="btn" href="work.html">Projekte ansehen</a>
+    <a class="btn" href="contact.html">Mit mir sprechen</a>
+  </div>
+</main>
+<section class="container section">
+  <div class="reveal">
+    <h2>Zukunftschancen erkennen</h2>
+    <p>Trends, Technologien und Nutzerperspektiven kombinieren, um neue Marktchancen zu entdecken.</p>
+  </div>
+  <div class="reveal" style="margin-top:40px;">
+    <h2>Von Idee zu Pilot</h2>
+    <p>Hypothesen schärfen, Prototypen testen und in Projekten validieren.</p>
+  </div>
+  <div class="reveal" style="margin-top:40px;">
+    <h2>Impact in Smart Home</h2>
+    <p>Digitale Produktstrategien, UX/Service-Design und Partner-Ökosysteme für vernetzte Erlebnisse.</p>
+  </div>
+</section>
+<section class="container section cred">
+  <div class="reveal">
+    <h3>Aktuell</h3>
+    <p>Strategic Concepter, Miele Smart Home (Bielefeld). Fokus: Future Business Design – von Vision zu validiertem Case.</p>
+  </div>
+</section>
+<footer class="footer">
+  © <span id="y"></span> Henrik Holkenbrink · Bielefeld · <a href="contact.html">Kontakt</a>
+</footer>
+<script src="assets/script.js"></script>
+</body>
+</html>

--- a/portfolio-henrik/work.html
+++ b/portfolio-henrik/work.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Work – Henrik Holkenbrink</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+<canvas id="particles"></canvas>
+<header class="container nav">
+  <a href="index.html" class="logo">← Zurück</a>
+  <nav class="nav-links">
+    <a href="work.html">Work</a>
+    <a href="approach.html">Approach</a>
+    <a href="about.html">About</a>
+    <a href="writing.html">Writing</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+<main class="container section">
+  <h1 class="reveal">Work</h1>
+  <p class="reveal">Ausgewählte Cases mit Ergebnisfokus. Details sind generisch gehalten und offen für Freigaben.</p>
+
+  <div class="case reveal">
+    <h2>Energy-Aware Home Experiences</h2>
+    <p>Ausgangspunkt: Wachsende Energiekosten und Nachhaltigkeitsziele fördern ressourcenbewusste Smart-Home-Szenarien.</p>
+    <p>Beitrag: Nutzerbedarfe identifiziert, Use-Cases priorisiert, Flows getestet, Partner-APIs bewertet.</p>
+    <p>Ergebnis: Pilot mit validierten Nutzungsmetriken, Roadmap-Fundament fürs MVP.</p>
+    <p class="tags">Strategy & Sizing · UX/Service Design · Rapid Prototyping · Experiment Design · Partner Alignment</p>
+  </div>
+
+  <div class="case reveal">
+    <h2>Data-Driven Kitchen Journeys</h2>
+    <p>Ausgangspunkt: Verknüpfung von Geräten, Zutaten und Rezepten für alltagsnahe Mehrwerte.</p>
+    <p>Beitrag: Journey-Mapping, Interaktionskonzept, Datenschutz-by-Design, Experiment-Backlog.</p>
+    <p>Ergebnis: Getestete Navigationsmuster, höhere Task-Completion, fundierte Business-Hypothesen.</p>
+    <p class="tags">Discovery · Interaction Design · Privacy · Usability · Hypothesis Building</p>
+  </div>
+
+  <div class="case reveal">
+    <h2>Partner Ecosystem Co-Creation</h2>
+    <p>Ausgangspunkt: Ökosystem-Mehrwert durch Kollaboration mit Startups/Universitäten/Communities.</p>
+    <p>Beitrag: Challenge-Design, Mentoring, Experimentformate, Pitch-Kriterien.</p>
+    <p>Ergebnis: Validierte Partner-Use-Cases für weitere Exploration.</p>
+    <p class="tags">Challenge Design · Mentoring · Experiments · Ecosystem Strategy</p>
+  </div>
+</main>
+<footer class="footer">
+  © <span id="y"></span> Henrik Holkenbrink · <a href="contact.html">Kontakt</a>
+</footer>
+<script src="assets/script.js"></script>
+</body>
+</html>

--- a/portfolio-henrik/writing.html
+++ b/portfolio-henrik/writing.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Writing & Speaking – Henrik Holkenbrink</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+<canvas id="particles"></canvas>
+<header class="container nav">
+  <a href="index.html" class="logo">← Zurück</a>
+  <nav class="nav-links">
+    <a href="work.html">Work</a>
+    <a href="approach.html">Approach</a>
+    <a href="about.html">About</a>
+    <a href="writing.html">Writing</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+<main class="container section">
+  <h1 class="reveal">Writing & Speaking</h1>
+  <p class="reveal">Geplante Beiträge zu nachhaltigen Use-Cases im Smart Home, datengetriebenen Journeys und Validierung in Pilotprojekten.</p>
+  <ul class="reveal" style="margin-top:20px;">
+    <li>3–5 Kurzartikel (700–900 Wörter)</li>
+    <li>Slides: Vision-to-Validation im Smart Home</li>
+  </ul>
+</main>
+<footer class="footer">
+  © <span id="y"></span> Henrik Holkenbrink · <a href="contact.html">Kontakt</a>
+</footer>
+<script src="assets/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add minimal Henrik portfolio with navigation, sections and contact page
- style for minimalist museum-like layout with scroll reveal and particle background
- include canvas-based particle animation and smooth scroll behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689501495af083219ab04ec072613234