### PR TITLE
Add portfolio page link to event overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,20 @@
         </a>
       </div>
       <div class="col-md-5 mb-3">
+        <a href="portfolio-henrik/index.html" class="text-decoration-none text-light">
+          <div class="card bg-secondary">
+            <div class="card-body text-center">
+              <svg width="64" height="64" viewBox="0 0 64 64" class="mb-2" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <rect x="12" y="20" width="40" height="32" rx="4" ry="4" stroke="currentColor" stroke-width="4" fill="none"/>
+                <path d="M24 20v-4a8 8 0 0 1 16 0v4" stroke="currentColor" stroke-width="4" fill="none"/>
+                <line x1="12" y1="32" x2="52" y2="32" stroke="currentColor" stroke-width="4"/>
+              </svg>
+              <h2>Portfolio</h2>
+            </div>
+          </div>
+        </a>
+      </div>
+      <div class="col-md-5 mb-3">
         <a href="universal-home-timeslots.html" class="text-decoration-none text-light">
           <div class="card bg-secondary">
             <div class="card-body text-center">


### PR DESCRIPTION
## Summary
- add a card linking to portfolio-henrik within the main event selection page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689504e9147c8321b63f5f97e85b8a1e