### PR TITLE
Add cron schedule validation for Vercel Hobby plan

### DIFF
--- a/cron-validator.js
+++ b/cron-validator.js
@@ -1,0 +1,20 @@
+function isHobbyCronValid(expression) {
+  const exp = expression.trim();
+  if (exp === '@daily' || exp === '@midnight') return true;
+  const parts = exp.split(/\s+/);
+  if (parts.length !== 5) return false;
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = parts;
+  return isSingle(minute, 0, 59) &&
+         isSingle(hour, 0, 23) &&
+         dayOfMonth === '*' &&
+         month === '*' &&
+         dayOfWeek === '*';
+}
+
+function isSingle(field, min, max) {
+  if (!/^\d+$/.test(field)) return false;
+  const num = Number(field);
+  return num >= min && num <= max;
+}
+
+module.exports = { isHobbyCronValid };

--- a/cron-validator.test.js
+++ b/cron-validator.test.js
@@ -1,0 +1,18 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const { isHobbyCronValid } = require('./cron-validator');
+
+test('hourly cron alias is invalid for Hobby plan', () => {
+  assert.strictEqual(isHobbyCronValid('@hourly'), false);
+});
+
+test('daily cron expression is valid for Hobby plan', () => {
+  assert.strictEqual(isHobbyCronValid('0 0 * * *'), true);
+});
+
+test('vercel.json schedule complies with Hobby plan', () => {
+  const config = JSON.parse(fs.readFileSync('./vercel.json', 'utf8'));
+  const schedule = config.crons[0].schedule;
+  assert.strictEqual(isHobbyCronValid(schedule), true);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/daily-task",
+      "schedule": "0 0 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` with daily cron schedule to avoid Hobby plan frequency limits
- implement `isHobbyCronValid` helper to validate cron expressions
- test cron validation and ensure config schedule complies with Hobby plan
- drop explicit `0 * * * *` example from tests, using `@hourly` alias instead

## Testing
- `node --test cron-validator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6e905e60083218297596077536425